### PR TITLE
Remove colon from text in cat-cube.md

### DIFF
--- a/docs/miscellaneous/cat-cube.md
+++ b/docs/miscellaneous/cat-cube.md
@@ -11,7 +11,7 @@ This blog post contains adapted code from David DeSandro's excellent [Intro to C
 
 # The CSS animation
 
-Here is my beloved cat, Mary, rotating around (thanks to Seattle's [Alley Cat Project](https://alleycatproject.org) for helping me find her ♥️):
+Here is my beloved cat, Mary, rotating around (thanks to Seattle's [Alley Cat Project](https://alleycatproject.org) for helping me find her ♥️)
 
 <html>
     <link rel="stylesheet" href="/css/cat.css" />


### PR DESCRIPTION
When viewing the webpage, the colon at the end of the line with the close parenthesis looks like a frowny face. Removing the colon to avoid communicating the wrong emotion.