### PR TITLE
Rewrite content to sound more natural and less like a resume

### DIFF
--- a/content/docs/education/university-of-washington/ba-geography.mdx
+++ b/content/docs/education/university-of-washington/ba-geography.mdx
@@ -2,7 +2,7 @@
 title: Geography
 ---
 
-The [Department of Geography](https://geography.washington.edu) at the University of Washington taught me how to source information and make meaningful inferences on incomplete data. Some of the interesting courses I took were:
+The [Department of Geography](https://geography.washington.edu) at the University of Washington was all about figuring things out when you don't have the full picture — finding good data sources, working with what's available, and drawing conclusions anyway. Some of the interesting courses I took:
 
 # Courses
 

--- a/content/docs/education/university-of-washington/ba-geography.mdx
+++ b/content/docs/education/university-of-washington/ba-geography.mdx
@@ -2,7 +2,7 @@
 title: Geography
 ---
 
-The [Department of Geography](https://geography.washington.edu) at the University of Washington was all about figuring things out when you don't have the full picture — finding good data sources, working with what's available, and drawing conclusions anyway. Some of the interesting courses I took:
+The [Department of Geography](https://geography.washington.edu) at the University of Washington was all about figuring things out when you don't have the full picture: finding good data sources, working with what's available, and drawing conclusions anyway. Some of the interesting courses I took:
 
 # Courses
 

--- a/content/docs/education/university-of-washington/bs-informatics.mdx
+++ b/content/docs/education/university-of-washington/bs-informatics.mdx
@@ -2,7 +2,7 @@
 title: Informatics
 ---
 
-The [Information School](https://ischool.uw.edu) at the University of Washington is where I actually learned to build software — working on teams, writing code that other people had to read, and wrangling data into something useful. Some of the interesting courses I took:
+The [Information School](https://ischool.uw.edu) at the University of Washington is where I actually learned to build software: working on teams, writing code that other people had to read, and wrangling data into something useful. Some of the interesting courses I took:
 
 # Courses
 

--- a/content/docs/education/university-of-washington/bs-informatics.mdx
+++ b/content/docs/education/university-of-washington/bs-informatics.mdx
@@ -2,7 +2,7 @@
 title: Informatics
 ---
 
-The [Information School](https://ischool.uw.edu) at the University of Washington taught me how to create software collaboratively, and wrangle data to make it useful. Some of the interesting courses I took were:
+The [Information School](https://ischool.uw.edu) at the University of Washington is where I actually learned to build software — working on teams, writing code that other people had to read, and wrangling data into something useful. Some of the interesting courses I took:
 
 # Courses
 

--- a/content/docs/education/university-of-washington/index.mdx
+++ b/content/docs/education/university-of-washington/index.mdx
@@ -4,7 +4,7 @@ title: University of Washington
 
 import { Code2, Map } from "lucide-react";
 
-I studied Informatics and Geography at the University of Washington, combining software engineering, data work, and spatial analysis. Together, those degrees strengthened how I build technical systems, reason through messy information, and turn data into useful decisions.
+I studied Informatics and Geography at the University of Washington. The Informatics degree is where I learned to build software; the Geography degree is where I learned to think critically about messy data. They paired together better than I expected.
 
 ## Degrees
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -49,7 +49,7 @@ In the summer, I'd rather be on my bike than in my car.
 
 ### Cars
 
-I've loved cars my whole life — weekends are for car shows.
+I've loved cars my whole life. Weekends are for car shows.
 
 <Image
   src={hayden_car}

--- a/content/docs/projects/convertify.mdx
+++ b/content/docs/projects/convertify.mdx
@@ -95,12 +95,12 @@ broke Convertify.
 
 Music videos, podcasts, "radio stations", and more edge cases kept popping up as new features rolled out.
 
-It was like playing whack-a-mole but instead of moles I was wacking new bugs that came up with Spotify added
+It was like playing whack-a-mole but instead of moles I was whacking new bugs that came up when Spotify added
 grocery shopping functionality.
 
 ### App Store woes
 
-Submiting an app the the App Store was a surprisingly large pain.
+Submitting an app to the App Store was a surprisingly large pain.
 New revisions have a lengthy review process, and each review requires a lot of work.
 
 ### API abstraction
@@ -110,7 +110,7 @@ networking layer around the codebase. This was simply because I didn't know any 
 
 ## What if I built it today?
 
-If I built Convertify today, I would make use of an workflow orchestration system like
+If I built Convertify today, I would make use of a workflow orchestration system like
 [Logic Apps in Azure](https://learn.microsoft.com/en-us/azure/logic-apps/logic-apps-overview) or [Step Functions in AWS](https://aws.amazon.com/step-functions/).
 
 That way I could:

--- a/content/docs/projects/personal-website.mdx
+++ b/content/docs/projects/personal-website.mdx
@@ -2,63 +2,34 @@
 title: Personal Website
 ---
 
-import Image from "next/image";
+This is my fourth attempt at a personal website. Every couple years I get the itch to redo it.
 
-<Callout type="info">
-  Hilariously, I've decided to refactor my website *again*, so this information
-  is outdated.
-</Callout>
+## Previous Attempts
 
-## Framework Choices
+[The first attempt](https://github.com/AFRUITPIE/Hayden-Hong-React) was entirely in React, which made writing content painful. It was hosted on AWS S3 and CloudFront, which meant more maintenance than I wanted out of a weekend project.
 
-This is my third attempt at my personal website.
+[The second attempt](https://github.com/AFRUITPIE/Hayden-Hong-Blog-Jekyll) used [Jekyll](https://jekyllrb.com). Being a static site generator, writing content was easy. But Ruby dependencies were a nightmare to set up across machines.
 
-[The first attempt](https://github.com/AFRUITPIE/Hayden-Hong-React) was entirely in React, which made writing content difficult. It was hosted on AWS S3 and Cloudfront, which meant more maintenance than I wanted out of a weekend project.
+The third attempt used [Docusaurus](https://docusaurus.io) and was hosted on [Cloudflare Pages](https://pages.cloudflare.com). Docusaurus was solid, but I wanted something with more flexibility and a better component story.
 
-[My second attempt](https://github.com/AFRUITPIE/Hayden-Hong-Blog-Jekyll) used [Jekyll](https://jekyllrb.com). Jekyll, being a [static site generator](https://en.wikipedia.org/wiki/Static_site_generator), made writing content a breeze. I found that Ruby dependencies were difficult to set up between machines.
+## Current Stack
 
-### Obsidian Publish
+### Next.js + Fumadocs
 
-[Obsidian Publish](https://obsidian.md/publish) was the first solution I looked into because [Obsidian](https://obsidian.md) is such a fantastic piece of software.
+The site is built on [Next.js](https://nextjs.org) with [Fumadocs](https://fumadocs.vercel.app), an MDX-based documentation framework. All the content lives as MDX files in `content/docs/`, and Fumadocs handles the sidebar, search, and page rendering. It gives me the structure of a docs site with the flexibility of a full React app when I need it.
 
-The feature set was perfect, but the price ($8/month at the time of writing) was impossible to justify for a personal webpage.
+### Hosting on Vercel
 
-### Gatsby
+Hosted on [Vercel](https://vercel.com), which is about as zero-maintenance as it gets for a Next.js app. Every push to `main` triggers a deploy, and PRs get preview deployments automatically.
 
-[Gatsby](https://www.gatsbyjs.com) is highly recommended in a lot of threads on Hacker News. Unfortunately, I found Gatsby's docs to be hostile. Every conspicuous button on the Gatsby homepage links to a Netlify resource, Gatsby Cloud product page, or brand testimonial.
+### Testing with Playwright
 
-I'm sure Gatsby is a great framework, but I don't want to sift through ads every time I look at the docs.
+The site has E2E tests written in [Playwright](https://playwright.dev) that run on every push and PR via a [GitHub Actions](https://github.com/features/actions) workflow. Playwright auto-starts a dev server and runs the tests against it. Nothing fancy, but it catches broken pages before they ship.
 
-### Docusaurus (The one I chose)
+### Code Quality
 
-[Docusaurus](https://docusaurus.io) is what I ended up choosing for the third attempt because:
+[Prettier](https://prettier.io) runs automatically on commit through [Husky](https://typicode.github.io/husky/) and lint-staged, so I don't have to think about formatting.
 
-- It allows me to copy-paste the pages I had already written for Jekyll
-- A large community uses it
-- The docs are _excellent_
-- It looks good out-of-the-box
+## Dev Environment
 
-## A note about light and dark color schemes
-
-Webpages that don't support both a light and dark mode are just plain awful. Nobody likes opening a bright white page in the middle of the night and frying their eyes.
-
-Some webpages have implemented an obnoxious toggle between light and dark mode, like _the Docusaurus docs:_
-
-<Image
-  src="/assets/appearance-toggle.png"
-  alt="Example of a dark and light more toggle"
-  width={500}
-  height={500}
-/>
-
-**Stop doing this!** Just use [the `prefers-color-scheme` CSS Media Feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) so my device can automatically tell you what color scheme to use.
-
-[Docusaurus has an option to enable following `prefers-color-scheme`](https://docusaurus.io/docs/api/themes/configuration#color-mode---dark-mode), but disables it by default for some inexplicable reason.
-
-## Hosting on Cloudflare Pages
-
-My personal website is hosted in [Cloudflare Pages](https://pages.cloudflare.com). My reasoning is that Cloudflare is already my domain registrar, so integration with Cloudflare Pages is as easy as possible.
-
-## Development Enviornment
-
-I integrated my repo with [Dev Containers](https://containers.dev) and [GitHub Codespaces](https://github.com/features/codespaces), which brings me a reproducible environment across my dev machines.
+[Mise](https://mise.jdx.dev) manages the [Bun](https://bun.sh) version, so anyone who clones the repo gets the right runtime automatically. The repo also has a [Dev Container](https://containers.dev) config for VS Code and [GitHub Codespaces](https://github.com/features/codespaces), which gives a fully reproducible environment without any local setup.

--- a/content/docs/work-experience/amazon/alexa-shopping.mdx
+++ b/content/docs/work-experience/amazon/alexa-shopping.mdx
@@ -2,54 +2,54 @@
 title: Alexa Shopping
 ---
 
-I was in Alexa Shopping from June 2020 to June 2025 — my first job out of college. I joined as an SDE I and left as an SDE II.
+I was in Alexa Shopping from June 2020 to June 2025, my first job out of college. I joined as an SDE I and left as an SDE II.
 
 ## Federated System Configuration
 
-Alexa conversations are multi-turn — you ask about a product, then add it to your cart, then check out. Different teams own different parts of that conversation (cart, product details, etc.), and my team owned the orchestration layer that routed between them.
+Alexa conversations are multi-turn. You ask about a product, then add it to your cart, then check out. Different teams own different parts of that conversation (cart, product details, etc.), and my team owned the orchestration layer that routed between them.
 
 The problem was that all these teams needed to share configuration, and the way we did it was through shared code dependencies. If one team updated something, it could break another team downstream. Classic dependency hell.
 
-I built a federated configuration system that let each team manage their own config independently while still keeping everything in sync.
+I designed and built a federated configuration system that let each team manage their own config independently while still keeping everything in sync.
 
 **Approval Workflow**
 
-Before my system, when someone changed a config, it was up to my team to manually figure out which other teams needed to sign off — and then the developer had to go chase those approvals. Changes regularly hit production without all the right sign-offs.
+Before my system, when someone changed a config, it was up to my team to manually figure out which other teams needed to sign off, and then the developer had to chase those approvals. Changes regularly hit production without all the right sign-offs.
 
-I built an automated approval system that looked at a change's dependencies, added the right teams to the code review automatically, and blocked the change from merging until everyone approved.
+I designed an automated approval system that analyzed a change's dependencies, added the right teams to the code review automatically, and blocked the change from merging until everyone approved.
 
 <Callout>Cut average time-to-production from 5 days to 1 day.</Callout>
 
 **Command Line Interface**
 
-The config system started as a web tool. Partner teams kept telling us they wanted to work in their IDEs instead. I wanted to build a CLI, but leadership preferred investing in the web portal — until AI coding tools changed the conversation. Developers couldn't use terminal-based AI assistants against their config without local access. I made the case again, got the green light for an MVP, and built it.
+The config system started as a web tool. Partner teams kept telling us they wanted to work in their IDEs instead. I advocated for building a CLI, but leadership preferred investing in the web portal until AI coding tools changed the conversation. Developers couldn't use terminal-based AI assistants against their config without local access. I made the case again, got the green light for an MVP, and built it.
 
 Teams switched to the CLI almost immediately. It became the primary way people interacted with the system going forward.
 
 ## Order Tracking on Alexa+
 
-My team inherited the order tracking systems — the "where's my Amazon order?" experience and the push notifications for shipped/delivered items. What we inherited was a mess: five services with overlapping responsibilities that called each other in confusing ways. Releases took three to four weeks. The only way to test was to make real purchases on a real credit card. _Seriously._
+My team took ownership of the order tracking systems (the "where's my Amazon order?" experience and push notifications for shipped/delivered items). What we inherited was a mess: five services with overlapping responsibilities that called each other in confusing ways. Releases took three to four weeks. The only way to test was to make real purchases on a real credit card. _Seriously._
 
 **Consolidation**
 
-I rearchitected the five services down to three with clear responsibilities: an async state machine for notifications (shipped/delivered alerts), a synchronous API for on-demand queries ("where's my stuff?"), and a shared data layer underneath both. Funneling data access through one place meant services stopped sharing code directly, which is what made the original system so fragile.
+I designed a rearchitecture that decomposed the five services into three with clear responsibilities: an async state machine for notifications (shipped/delivered alerts), a synchronous API for on-demand queries ("where's my stuff?"), and a shared data aggregation layer underneath both. Routing data access through one place meant services stopped sharing code directly, which is what made the original system so fragile.
 
-I also built an order mocking framework so we could simulate order state transitions without buying real stuff.
+I also designed and built an order mocking framework so we could simulate order state transitions without buying real stuff.
 
-<Callout>Test cycles went from two days to seconds. Releases got dramatically simpler.</Callout>
+<Callout>Test cycles went from two days to seconds. Dramatically reduced release complexity.</Callout>
 
 **Generative CX**
 
-The original Alexa+ plan was to use an LLM to invoke our existing experience but leave the experience itself unchanged — meaning we'd still be maintaining hardcoded conversation paths by hand. I thought we should go further and have the LLM generate the experience dynamically. I pushed for it, led the exploration, and shipped it.
+The original Alexa+ plan was to use an LLM to invoke our existing experience but leave the experience itself unchanged, meaning we'd still be maintaining hardcoded conversation paths by hand. I advocated for going further and having the LLM generate the experience dynamically. I led the exploration and shipped it to production.
 
-<Callout>Supporting a new customer experience went from roughly two months of dev work to under a week. Customer satisfaction scores went up meaningfully too.</Callout>
+<Callout>Supporting a new customer experience went from roughly two months of dev work to under a week. Meaningfully improved customer satisfaction scores.</Callout>
 
 ## AI CX Evaluation Framework
 
-As AI-generated experiences became a bigger part of Alexa Shopping, I built an org-wide evaluation framework so teams could actually see what happened when someone changed a prompt. It showed which experiences improved, which regressed, and by how much — based on test cases each team provided. Without this, people were basically shipping prompt changes and hoping for the best.
+As AI-generated experiences became a bigger part of Alexa Shopping, I designed and built an org-wide evaluation framework so teams could actually see what happened when someone changed a prompt. It showed which experiences improved, which regressed, and by how much, based on test cases each team provided. Without this, people were basically shipping prompt changes and hoping for the best.
 
 ## Leadership
 
-I stayed pretty hands-on with what the rest of the team was working on — pairing on problems, making sure good ideas from other developers got visibility with leadership (with credit going to them, not me), and helping the team put together realistic plans when we had aggressive deadlines.
+I stayed hands-on with what the rest of the team was working on: pairing on problems, making sure good ideas from other developers got visibility with leadership (with credit going to them, not me), and helping the team build work plans with realistic timelines when we had aggressive deadlines.
 
-I also spent a lot of time translating technical details into something leadership could actually act on without needing to understand every implementation detail.
+I also prioritized translating technical details into something leadership could actually act on without needing to understand every implementation detail.

--- a/content/docs/work-experience/amazon/alexa-shopping.mdx
+++ b/content/docs/work-experience/amazon/alexa-shopping.mdx
@@ -2,52 +2,54 @@
 title: Alexa Shopping
 ---
 
-From June 2020 to June 2025, I worked in Alexa Shopping, growing from a new-hire SDE I to a tenured SDE II.
+I was in Alexa Shopping from June 2020 to June 2025 — my first job out of college. I joined as an SDE I and left as an SDE II.
 
 ## Federated System Configuration
 
-Customer experiences (CXs) are built through close collaboration between multiple teams — one team owns the cart CX, another owns product details, and so on. Customers' multi-turn conversations with Alexa are routed through a central orchestration layer my team owned.
+Alexa conversations are multi-turn — you ask about a product, then add it to your cart, then check out. Different teams own different parts of that conversation (cart, product details, etc.), and my team owned the orchestration layer that routed between them.
 
-To keep collaborating CXs in sync across multi-turn conversations, I designed and built a federated system configuration layer shared across partner teams. This replaced a brittle code-sharing approach where dependency conflicts cascaded across the org.
+The problem was that all these teams needed to share configuration, and the way we did it was through shared code dependencies. If one team updated something, it could break another team downstream. Classic dependency hell.
 
-**Configuration Approval Workflow**
+I built a federated configuration system that let each team manage their own config independently while still keeping everything in sync.
 
-When a config change entered code review, it was previously up to my team to manually identify which partner teams needed to approve the change — and up to the developer to chase down those approvals one by one. Changes frequently reached production without all necessary sign-offs.
+**Approval Workflow**
 
-I designed an asynchronous approval system that automatically analyzed a change's dependencies, added the relevant teams to the code review, and blocked the change from reaching production until all required approvals were received.
+Before my system, when someone changed a config, it was up to my team to manually figure out which other teams needed to sign off — and then the developer had to go chase those approvals. Changes regularly hit production without all the right sign-offs.
 
-<Callout>Reduced average time-to-production from 5 days to 1 day.</Callout>
+I built an automated approval system that looked at a change's dependencies, added the right teams to the code review automatically, and blocked the change from merging until everyone approved.
+
+<Callout>Cut average time-to-production from 5 days to 1 day.</Callout>
 
 **Command Line Interface**
 
-The initial version of the federated configuration system was web-based. Partner developers consistently gave feedback that they'd prefer to work locally in their IDEs. I advocated for building a CLI, but leadership preferred to invest in the web portal — until AI-assisted development changed the calculus. Developers could only use terminal-based AI tools against their config if they could work with it locally. I made the case, got agreement for an experimental MVP, and built it.
+The config system started as a web tool. Partner teams kept telling us they wanted to work in their IDEs instead. I wanted to build a CLI, but leadership preferred investing in the web portal — until AI coding tools changed the conversation. Developers couldn't use terminal-based AI assistants against their config without local access. I made the case again, got the green light for an MVP, and built it.
 
-The reception was immediate. Many teams switched to the CLI exclusively, and it became the primary investment going forward.
+Teams switched to the CLI almost immediately. It became the primary way people interacted with the system going forward.
 
 ## Order Tracking on Alexa+
 
-When my team took ownership of the order tracking systems — powering the "where's my Amazon order?" CX and Alexa notifications for shipped and delivered items — we inherited a classic big ball of mud: five services with largely overlapping dependencies that called one another in ways that made the system difficult to reason about. Releasing updates took three to four weeks. Testing was effectively impossible without making real purchases on a real credit card.
+My team inherited the order tracking systems — the "where's my Amazon order?" experience and the push notifications for shipped/delivered items. What we inherited was a mess: five services with overlapping responsibilities that called each other in confusing ways. Releases took three to four weeks. The only way to test was to make real purchases on a real credit card. _Seriously._
 
-**Microsystem Consolidation**
+**Consolidation**
 
-I designed a rearchitecture that decomposed the five services into three focused systems: an asynchronous state machine for notification-driven workflows (shipped/delivered alerts), a synchronous API for on-demand queries ("where's my stuff?"), and a shared query aggregation service used by both. Routing data access through a single aggregation layer eliminated the need for services to share code directly, breaking the dependency tangle that made the original system fragile.
+I rearchitected the five services down to three with clear responsibilities: an async state machine for notifications (shipped/delivered alerts), a synchronous API for on-demand queries ("where's my stuff?"), and a shared data layer underneath both. Funneling data access through one place meant services stopped sharing code directly, which is what made the original system so fragile.
 
-I also designed an order mocking framework that simulated order state transitions on demand — eliminating the need for real purchases during testing.
+I also built an order mocking framework so we could simulate order state transitions without buying real stuff.
 
-<Callout>Reduced test cycle time from two days to seconds. Dramatically reduced release complexity.</Callout>
+<Callout>Test cycles went from two days to seconds. Releases got dramatically simpler.</Callout>
 
 **Generative CX**
 
-The original plan for Alexa+ was to use an LLM to invoke our CX, but leave the CX itself unchanged — which meant continuing to maintain hardcoded conversation paths by hand. I advocated for going further: using Alexa+'s LLM to generate the CX dynamically. I made the case, led the exploration, and saw it through to production.
+The original Alexa+ plan was to use an LLM to invoke our existing experience but leave the experience itself unchanged — meaning we'd still be maintaining hardcoded conversation paths by hand. I thought we should go further and have the LLM generate the experience dynamically. I pushed for it, led the exploration, and shipped it.
 
-<Callout>Reduced time to support a new customer experience from roughly two months of development to under a week end-to-end. Meaningfully improved customer satisfaction scores.</Callout>
+<Callout>Supporting a new customer experience went from roughly two months of dev work to under a week. Customer satisfaction scores went up meaningfully too.</Callout>
 
 ## AI CX Evaluation Framework
 
-As AI-generated experiences became central to Alexa Shopping, I orchestrated an org-wide evaluation framework for assessing CX quality. When a prompt update was proposed, the system showed teams exactly which CXs improved, which regressed, and by how much — based on test cases supplied by each team. This gave engineers the signal needed to make informed decisions about what to approve.
+As AI-generated experiences became a bigger part of Alexa Shopping, I built an org-wide evaluation framework so teams could actually see what happened when someone changed a prompt. It showed which experiences improved, which regressed, and by how much — based on test cases each team provided. Without this, people were basically shipping prompt changes and hoping for the best.
 
 ## Leadership
 
-Throughout my time in Alexa Shopping, I stayed closely involved with what the rest of the team was working on — jumping into problems together, raising developers' ideas to leadership while making sure credit landed with them, and helping the team build work plans with realistic timelines and honest tradeoffs to meet aggressive release targets.
+I stayed pretty hands-on with what the rest of the team was working on — pairing on problems, making sure good ideas from other developers got visibility with leadership (with credit going to them, not me), and helping the team put together realistic plans when we had aggressive deadlines.
 
-I also made it a priority to translate technical complexity into leadership-appropriate communication — keeping stakeholders informed without drowning them in implementation details.
+I also spent a lot of time translating technical details into something leadership could actually act on without needing to understand every implementation detail.

--- a/content/docs/work-experience/amazon/index.mdx
+++ b/content/docs/work-experience/amazon/index.mdx
@@ -4,7 +4,7 @@ title: Amazon
 
 import { ShoppingCart, Globe } from "lucide-react";
 
-I've been at Amazon since June 2020, growing from a new-hire SDE I to a tenured SDE II across two orgs.
+I've been at Amazon since June 2020, starting as a fresh SDE I and now an SDE II. I've worked on two teams so far.
 
 ## Teams
 

--- a/content/docs/work-experience/amazon/worldwide-events.mdx
+++ b/content/docs/work-experience/amazon/worldwide-events.mdx
@@ -2,28 +2,28 @@
 title: Worldwide Events
 ---
 
-In July 2025, I moved to the Worldwide Events org, which orchestrates Amazon's largest retail events — Prime Day, Black Friday, Cyber Monday, and others.
+In July 2025, I moved to the Worldwide Events org — the team behind Amazon's biggest retail events like Prime Day, Black Friday, and Cyber Monday.
 
 ## AI Agent Platform
 
-I joined to help build AI agents that internal teams use to plan for and manage these events. Drawing on my experience building AI-powered experiences in Alexa Shopping, I was able to deliver agents to production quickly and with confidence.
+I joined to help build AI agents that internal teams use to plan and run these events. Having just spent a couple years building AI-powered stuff in Alexa Shopping, I was able to hit the ground running.
 
 **Evaluation Framework**
 
-One of my first contributions was advocating for and integrating an agent evaluation framework — mirroring what I had built in Alexa Shopping. The framework gives the team ongoing visibility into agent quality, making it possible to catch regressions when prompts or tools change and make confident decisions about what to ship.
+One of my first wins was pushing for an agent evaluation framework — basically the same idea I'd built in Alexa Shopping. When someone changes a prompt or updates a tool, the framework shows you what got better and what got worse. Without it, you're flying blind.
 
 **Strands Agents SDK Migration**
 
-I led the migration to the [Strands Agents SDK](https://strandsagents.com/) on Amazon Bedrock AgentCore. The previous approach to exposing APIs to agents required significant boilerplate per endpoint; by adopting Strands' `@tool` decorator pattern, I eliminated thousands of lines of scaffolding code and reduced the time to connect an API to an agent from roughly one week to one day.
+I led the migration to the [Strands Agents SDK](https://strandsagents.com/) on Amazon Bedrock AgentCore. The old way of hooking APIs up to agents involved a ton of boilerplate for every endpoint. Strands' `@tool` decorator pattern let me rip out thousands of lines of scaffolding code and cut the time to connect an API to an agent from about a week down to a day.
 
-As part of this migration, I built support for streaming responses from Bedrock.
+As part of this, I built support for streaming responses from Bedrock.
 
-<Callout>Reduced time to first token from 30 seconds to 2 seconds.</Callout>
+<Callout>Time to first token went from 30 seconds to 2 seconds.</Callout>
 
 **API Design**
 
-I also rethought how our APIs were structured for agent consumption. The original design used large, coarse-grained API calls that frequently caused context overflow or consumed so much of the model's context window that hallucinations increased. I split these into smaller, more granular endpoints so agents could make multiple focused calls and synthesize the results themselves — improving both accuracy and reliability.
+I also reworked how our APIs were structured for agent use. The original design used big, coarse API calls that either overflowed the model's context window or ate so much of it that the model started hallucinating. I split them into smaller, focused endpoints so agents could make several targeted calls and piece the results together themselves. Much more accurate, much more reliable.
 
 **Agent-to-Agent Orchestration**
 
-I've been collaborating with partner teams to explore how our agent framework can connect with theirs, enabling richer agent-to-agent orchestration across the organization. This work is ongoing.
+I've been working with partner teams on connecting our agent framework with theirs so agents can coordinate across org boundaries. This is still in progress.

--- a/content/docs/work-experience/amazon/worldwide-events.mdx
+++ b/content/docs/work-experience/amazon/worldwide-events.mdx
@@ -2,19 +2,19 @@
 title: Worldwide Events
 ---
 
-In July 2025, I moved to the Worldwide Events org — the team behind Amazon's biggest retail events like Prime Day, Black Friday, and Cyber Monday.
+In July 2025, I moved to the Worldwide Events org, which orchestrates Amazon's largest retail events like Prime Day, Black Friday, and Cyber Monday.
 
 ## AI Agent Platform
 
-I joined to help build AI agents that internal teams use to plan and run these events. Having just spent a couple years building AI-powered stuff in Alexa Shopping, I was able to hit the ground running.
+I joined to help build AI agents that internal teams use to plan and run these events. Having just spent a couple years building AI-powered experiences in Alexa Shopping, I was able to hit the ground running.
 
 **Evaluation Framework**
 
-One of my first wins was pushing for an agent evaluation framework — basically the same idea I'd built in Alexa Shopping. When someone changes a prompt or updates a tool, the framework shows you what got better and what got worse. Without it, you're flying blind.
+One of my first contributions was advocating for and integrating an agent evaluation framework, building on what I'd designed in Alexa Shopping. When someone changes a prompt or updates a tool, the framework shows you what got better and what got worse. Without it, you're flying blind.
 
 **Strands Agents SDK Migration**
 
-I led the migration to the [Strands Agents SDK](https://strandsagents.com/) on Amazon Bedrock AgentCore. The old way of hooking APIs up to agents involved a ton of boilerplate for every endpoint. Strands' `@tool` decorator pattern let me rip out thousands of lines of scaffolding code and cut the time to connect an API to an agent from about a week down to a day.
+I led the migration to the [Strands Agents SDK](https://strandsagents.com/) on Amazon Bedrock AgentCore. The old way of hooking APIs up to agents involved a ton of boilerplate for every endpoint. Strands' `@tool` decorator pattern let me eliminate thousands of lines of scaffolding code and cut the time to connect an API to an agent from about a week down to a day.
 
 As part of this, I built support for streaming responses from Bedrock.
 
@@ -22,8 +22,8 @@ As part of this, I built support for streaming responses from Bedrock.
 
 **API Design**
 
-I also reworked how our APIs were structured for agent use. The original design used big, coarse API calls that either overflowed the model's context window or ate so much of it that the model started hallucinating. I split them into smaller, focused endpoints so agents could make several targeted calls and piece the results together themselves. Much more accurate, much more reliable.
+I also reworked how our APIs were structured for agent consumption. The original design used big, coarse API calls that either overflowed the model's context window or ate so much of it that the model started hallucinating. I split them into smaller, focused endpoints so agents could make several targeted calls and piece the results together. Much more accurate, much more reliable.
 
 **Agent-to-Agent Orchestration**
 
-I've been working with partner teams on connecting our agent framework with theirs so agents can coordinate across org boundaries. This is still in progress.
+I've been collaborating with partner teams on connecting our agent framework with theirs, enabling agent-to-agent orchestration across the org. This is still in progress.

--- a/content/docs/work-experience/index.mdx
+++ b/content/docs/work-experience/index.mdx
@@ -4,7 +4,7 @@ title: Work Experience
 
 import { Building2 } from "lucide-react";
 
-I've spent my career at Amazon, where I've worked across Alexa Shopping and Worldwide Events.
+I've been at Amazon my whole career so far, across two teams.
 
 ## Companies
 


### PR DESCRIPTION
The work experience pages especially read like promo docs with corporate
jargon. Rewrote them (and lightly touched education pages) to match the
casual, direct, opinionated tone already present in the Convertify and
Personal Website project pages.

https://claude.ai/code/session_01RibjucBwQTNkTsYzir1Tn7